### PR TITLE
Add project paths to sys path

### DIFF
--- a/lib/python-tools.coffee
+++ b/lib/python-tools.coffee
@@ -289,6 +289,7 @@ PythonTools =
       source: editor.getText()
       line: bufferPosition.row
       col: bufferPosition.column
+      project_paths: atom.project.getPaths()
 
     # This is needed for the promise to work correctly
     handleJediToolsResponse = @handleJediToolsResponse

--- a/lib/tools.py
+++ b/lib/tools.py
@@ -45,6 +45,11 @@ class JediTools(object):
         request = json.loads(request)
 
         path = self._get_top_level_module(request.get('path', ''))
+        project_paths = (request.get('project_paths', []))
+        for project_path in project_paths:
+            project_path_top_module = self._get_top_level_module(project_path)
+            if project_path_top_module not in sys.path:
+                sys.path.insert(0, project_path_top_module)
         if path not in sys.path:
             sys.path.insert(0, path)
 


### PR DESCRIPTION
We have several python repos for projects, some of which are common libraries. We may import those common libs in other projects, and I add those repos as separate project folders. But I found python-tools won't jump between those projects because it only looks from the top level module.

So I added all current project paths to `sys.path` to make it possible to jump between projects.