### PR TITLE
Fix handling of environment path variable.

### DIFF
--- a/lib/python-tools.coffee
+++ b/lib/python-tools.coffee
@@ -46,6 +46,7 @@ PythonTools =
 
     env = process.env
     pythonPath = atom.config.get('python-tools.pythonPath')
+    path_env = null
 
     if /^win/.test process.platform
       paths = ['C:\\Python2.7',
@@ -63,9 +64,11 @@ PythonTools =
                'C:\\Program Files\\Python 2.7',
                'C:\\Program Files\\Python 3.4',
                'C:\\Program Files\\Python 3.5']
-    else:
+      path_env = (env.Path or '').split path.delimiter
+    else
       paths = ['/usr/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin']
-    path_env = (env.PATH or '').split path.delimiter
+      path_env = (env.PATH or '').split path.delimiter
+
     path_env.unshift pythonPath if pythonPath and pythonPath not in path_env
     for p in paths
       if p not in path_env


### PR DESCRIPTION
The fix takes the platform into account for evaluating the right environment
path variable.

Due to the case-sensitivity of the process.env object the python-tools package added a wrong "PATH"
variable to the env overwriting the actual windows "Path" variable. This causes a lot of tools not to
be found.

From my point of view it
Closes #34 #35 #36 #37 #38 #43 #47.
When you have python in your Windows "Path" variable every thing should be fine.