### PR TITLE
Add hyperclick support

### DIFF
--- a/lib/python-tools.coffee
+++ b/lib/python-tools.coffee
@@ -295,11 +295,11 @@ PythonTools = {
     else
       atom.notifications.addInfo("python-tools could not find any results!")
 
-  jediToolsRequest: (type, textEditor, range) ->
+  jediToolsRequest: (type, textEditor, position) ->
     editor = textEditor or atom.workspace.getActiveTextEditor()
     grammar = editor.getGrammar()
 
-    bufferPosition = range or editor.getCursorBufferPosition()
+    bufferPosition = position or editor.getCursorBufferPosition()
 
     payload = {
       type: type,
@@ -322,14 +322,16 @@ PythonTools = {
     )
 
   getProvider: () ->
+    jediToolsRequest = @jediToolsRequest.bind(this)
     return {
+      priority: 10,
       getSuggestionForWord: (textEditor, text, range) ->
         return {
           # The range(s) to underline as a visual cue for clicking.
           range,
           # The function to call when the underlined text is clicked.
           callback: () ->
-            @jediToolsRequest('gotoDef', textEditor, range)
+            return jediToolsRequest('gotoDef', textEditor, range.start)
         }
     }
 }

--- a/lib/python-tools.coffee
+++ b/lib/python-tools.coffee
@@ -295,11 +295,11 @@ PythonTools = {
     else
       atom.notifications.addInfo("python-tools could not find any results!")
 
-  jediToolsRequest: (type) ->
-    editor = atom.workspace.getActiveTextEditor()
+  jediToolsRequest: (type, textEditor, range) ->
+    editor = textEditor or atom.workspace.getActiveTextEditor()
     grammar = editor.getGrammar()
 
-    bufferPosition = editor.getCursorBufferPosition()
+    bufferPosition = range or editor.getCursorBufferPosition()
 
     payload = {
       type: type,
@@ -320,6 +320,18 @@ PythonTools = {
         resolve()
       )
     )
+
+  getProvider: () ->
+    return {
+      getSuggestionForWord: (textEditor, text, range) ->
+        return {
+          # The range(s) to underline as a visual cue for clicking.
+          range,
+          # The function to call when the underlined text is clicked.
+          callback: () ->
+            @jediToolsRequest('gotoDef', textEditor, range)
+        }
+    }
 }
 
 module.exports = PythonTools

--- a/package.json
+++ b/package.json
@@ -15,5 +15,12 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "providedServices": {
+      "hyperclick.provider": {
+        "versions": {
+          "0.0.0": "getProvider"
+        }
+      }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "python-tools",
   "main": "./lib/python-tools",
-  "version": "0.6.8",
+  "version": "0.7.0",
   "description": "Goto definition, show usages, refactor/rename and more for python files",
   "keywords": [
     "python",


### PR DESCRIPTION
Adds support for the fabulous `hyperclick` library (https://atom.io/packages/hyperclick) (https://github.com/facebooknuclideapm/hyperclick). Overrides the default path jump behavior to use jedi.
